### PR TITLE
Changes to get build to complete in JEDI environment.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 ########################################################################################################################
 ### dependencies and options
 
-ecbuild_use_package( PROJECT eckit  VERSION 1.9 REQUIRED )
+ecbuild_use_package( PROJECT eckit  VERSION 1.4 REQUIRED )
 
 ecbuild_add_option( FEATURE FORTRAN
                     DESCRIPTION "whether or not to build the Fortran interface"

--- a/tests/c_api/encode.cc
+++ b/tests/c_api/encode.cc
@@ -541,7 +541,7 @@ CASE("Encode to a file descriptor") {
     // Do the encoding
 
     eckit::TmpFile tf;
-    int fd = ::open(tf.asString().c_str(), O_CREAT|O_WRONLY);
+    int fd = ::open(tf.asString().c_str(), O_CREAT|O_WRONLY, S_IRUSR|S_IWUSR|S_IRGRP|S_IROTH);
     ASSERT(fd != -1);
     long sz;
     try {


### PR DESCRIPTION
This PR contains changes necessary to get the odc libraries to build and run in the JEDI environment. The change in the ``tests/c_api/encode.cc`` file was needed for the GNU compilers. Intel and Clang were okay with the open call without the 3rd argument.

Closes #1 