### PR TITLE
Speed up column index retrieval

### DIFF
--- a/src/odc/core/Exceptions.cc
+++ b/src/odc/core/Exceptions.cc
@@ -31,6 +31,14 @@ ODBInvalid::ODBInvalid(const std::string& file, const std::string& reason, const
 ODBEndOfDataStream::ODBEndOfDataStream(const std::string& s, const eckit::CodeLocation& loc) :
     ODBDecodeError(s, loc) {}
 
+
+AmbiguousColumnException::AmbiguousColumnException(const std::string& columnName) :
+    UserError("Ambiguous column name: '" + columnName + "'") {}
+
+
+ColumnNotFoundException::ColumnNotFoundException(const std::string& columnName) :
+    UserError("Column '" + columnName + "' not found.") {}
+
 //----------------------------------------------------------------------------------------------------------------------
 
 } // namespace core

--- a/src/odc/core/Exceptions.h
+++ b/src/odc/core/Exceptions.h
@@ -46,6 +46,20 @@ public:
     ODBEndOfDataStream(const std::string&, const eckit::CodeLocation&);
 };
 
+
+/// Exception thrown when a column without an associated table name is found in multiple tables.
+class AmbiguousColumnException : public eckit::UserError {
+ public:
+  explicit AmbiguousColumnException(const std::string& columnName);
+};
+
+/// Exception thrown when a requested column is not found.
+class ColumnNotFoundException : public eckit::UserError {
+ public:
+  explicit ColumnNotFoundException(const std::string& columnName);
+};
+
+
 //----------------------------------------------------------------------------------------------------------------------
 
 } // namespace core

--- a/src/odc/core/MetaData.cc
+++ b/src/odc/core/MetaData.cc
@@ -95,7 +95,7 @@ bool MetaData::hasColumn(const std::string& name) const
 
 size_t MetaData::columnIndex(const std::string& name) const
 {
-	const size_t notFound = static_cast<size_t>(-1);
+    const size_t notFound = std::numeric_limits<size_t>::max();
 	size_t index = notFound;
 
 	for (size_t i = 0; i < size(); i++)
@@ -103,11 +103,11 @@ size_t MetaData::columnIndex(const std::string& name) const
 			if (index == notFound)
 				index = i;
 			else
-				throw eckit::UserError(std::string("Ambiguous column name: '") + name + "'");
+                throw AmbiguousColumnException(name);
 		}
 
 	if (index == notFound)
-		throw eckit::UserError(std::string("Column '") + name + "' not found.");
+        throw ColumnNotFoundException(name);
 
 	return index;
 }

--- a/src/odc/core/MetaData.h
+++ b/src/odc/core/MetaData.h
@@ -163,6 +163,13 @@ MetaData& MetaData::addBitfieldPrivate(const std::string& name, const eckit::sql
 
 //----------------------------------------------------------------------------------------------------------------------
 
+/// Return true if `fullColumnName` is equal to `columnNamePossiblyWithoutTableName` or
+/// if it starts with `columnNamePossiblyWithoutTableName` followed by the `@` character.
+bool columnNameMatches(const std::string &fullColumnName,
+                       const std::string &columnNamePossiblyWithoutTableName);
+
+//----------------------------------------------------------------------------------------------------------------------
+
 } // namespace core
 } // namespace odc
 

--- a/src/odc/core/MetaData.h
+++ b/src/odc/core/MetaData.h
@@ -13,6 +13,7 @@
 
 #include "odc/core/Column.h"
 #include "eckit/sql/SQLTypedefs.h"
+#include "eckit/exception/Exceptions.h"
 
 #ifdef SWIGPYTHON
 #include "odc/IteratorProxy.h"
@@ -73,7 +74,21 @@ public:
     template<typename ByteOrder> MetaData& addBitfieldPrivate(const std::string& name, const eckit::sql::BitfieldDef&);
 
 	bool hasColumn(const std::string&) const;
+
+    /// \brief Return a pointer to the object representing the column with the specified name.
+    /// The name may, but does not need to, be qualified with a table name (e.g. both `varno` and
+    /// `varno@body` are accepted).
+    ///
+    /// This function throws the same exceptions as columnIndex().
 	Column* columnByName(const std::string&) const;
+
+    /// \brief Return the index of the column with the specified name. The name may, but does not
+    /// need to, be qualified with a table name (e.g. both `varno` and `varno@body` are accepted).
+    ///
+    /// If no column with this name is found, a ColumnNotFoundException is thrown.
+    ///
+    /// If the column name is not qualified with a table name and a column with this name is found
+    /// in multiple tables, an AmbiguousColumnException is thrown.
 	size_t columnIndex(const std::string&) const;
 
     static api::ColumnType convertType(const std::string&);

--- a/src/odc/sql/TODATableIterator.cc
+++ b/src/odc/sql/TODATableIterator.cc
@@ -10,7 +10,6 @@
 
 #include "eckit/sql/SQLColumn.h"
 #include "eckit/exception/Exceptions.h"
-#include "eckit/utils/StringTools.h"
 
 #include "odc/csv/TextReader.h"
 #include "odc/csv/TextReaderIterator.h"
@@ -33,16 +32,13 @@ size_t columnIndex(const std::string& columnName, const core::MetaData &md)
     size_t idx;
     try {
         idx = md.columnIndex(columnName);
-    } catch (const eckit::UserError &e) {
-        // Make some error messages more precise
-        if (eckit::StringTools::startsWith(e.what(), "Ambiguous column name:"))
-            throw eckit::UserError("Ambiguous column name \"" + columnName +
-                                   "\" specified in SQL request.", Here());
-        else if (eckit::StringTools::endsWith(e.what(), "not found."))
-            throw eckit::UserError("Column \"" + columnName +
-                                   "\" not found in table, but required in SQL request.", Here());
-        else
-            throw;
+    // Make some error messages more precise
+    } catch (const core::AmbiguousColumnException &e) {
+        throw eckit::UserError("Ambiguous column name \"" + columnName +
+                               "\" specified in SQL request.", Here());
+    } catch (const core::ColumnNotFoundException &e) {
+        throw eckit::UserError("Column \"" + columnName +
+                               "\" not found in table, but required in SQL request.", Here());
     }
     return idx;
 }

--- a/src/odc/tools/TestMetaData.cc
+++ b/src/odc/tools/TestMetaData.cc
@@ -45,6 +45,11 @@ static void test()
 
 	ASSERT(sum2.size() == md1.size() + md2.size());
 	ASSERT(sum == sum2);
+
+	ASSERT(columnNameMatches("column@body", "column@body"));
+	ASSERT(columnNameMatches("column@body", "column"));
+	ASSERT(!columnNameMatches("columns@body", "column"));
+	ASSERT(!columnNameMatches("another_column@body", "column"));
 }
 
 

--- a/tests/core/test_metadata.cc
+++ b/tests/core/test_metadata.cc
@@ -13,6 +13,7 @@
 #include "eckit/testing/Test.h"
 
 #include "odc/core/MetaData.h"
+#include "odc/Reader.h"
 #include "odc/Writer.h"
 
 using namespace eckit::testing;
@@ -55,6 +56,18 @@ CASE("Copy metadata in Writer") {
     eckit::Log::info() << "Found: " << it->columns().at(0)->dataSizeDoubles() << std::endl;
     EXPECT(it->columns().at(0)->dataSizeDoubles() == 2);
     EXPECT(it->columns().at(1)->dataSizeDoubles() == 1);
+}
+
+
+CASE("Missing/ambiguous column names") {
+    odc::Reader reader("../2000010106-reduced.odb");
+    auto it = reader.begin();
+    EXPECT(it != reader.end());
+    const odc::core::MetaData &md = it->columns();
+    EXPECT(md.columnIndex("event1@hdr") == 11);
+    EXPECT(md.columnIndex("event1@body") == 35);
+    EXPECT_THROWS_AS(md.columnIndex("event1"), odc::core::AmbiguousColumnException);
+    EXPECT_THROWS_AS(md.columnIndex("bogus"), odc::core::ColumnNotFoundException);
 }
 
 // ------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This PR makes the `TODATableIterator::updateMetaData()` function more efficient by
* performing the search for each column only once (by calling just `MetaData::columnIndex()`) rather than twice (with an extra call to `MetaData::hasColumn()`)
* avoiding repeated construction of a temporary string representing the column name with a `@` suffix
* removing an unnecessary call to `std::string::find()`.

On my system, this reduces the execution time of a query operating on a file containing 1,292,800 rows and 212 columns and producing an empty results set (and therefore effectively only decoding the file), i.e.
```
odc sql "select * where varno == -1" -i atms6K.odb -o /dev/null -f odb
```
by more than 25%: from 2.0 s to 1.4 s.