### PR TITLE
Static linking fix: specify linker language for Fortran tests

### DIFF
--- a/tests/f_api/CMakeLists.txt
+++ b/tests/f_api/CMakeLists.txt
@@ -12,6 +12,7 @@ foreach( _test ${_api_fodc_tests} )
         ENVIRONMENT  ${test_environment}
         TEST_DEPENDS odc_get_test_data
         CONDITION    HAVE_FORTRAN
+        LINKER_LANGUAGE Fortran
         LIBS         fodc )
 endforeach()
 
@@ -40,6 +41,7 @@ foreach( _i RANGE ${_count} )
                             SOURCES    ${_sources}.f90
                             LIBS       fodc
                             CONDITION  HAVE_FORTRAN
+                            LINKER_LANGUAGE Fortran
                             NOINSTALL )
 endforeach()
 


### PR DESCRIPTION
This small PR specifies the linker_language for Fortran tests. This fix is needed for static IFS builds (https://jira.ecmwf.int/browse/IFS-3364). Once merged, could you please tag a hotfix release? Thanks!

NB: this is a copy of this bitbucket PR: https://git.ecmwf.int/projects/ODB/repos/odc/pull-requests/29/overview. That can also be closed once this is merged.