### PR TITLE
Fix Column::isConstant

### DIFF
--- a/src/odc/core/Column.cc
+++ b/src/odc/core/Column.cc
@@ -90,7 +90,8 @@ bool Column::isConstant()
 {
 	// FIXME
 	return coder().name() == "constant"
-		|| coder().name() == "constant_string";
+		|| coder().name() == "constant_string"
+        || coder().name() == "long_constant_string";
 }
 
 //Column::Column(DataHandle *dataHandle) : dataHandle_(dataHandle), name_(), type_(IGNORE/*?*/), coder_(0) {}


### PR DESCRIPTION
The implementation of Column::isConstant could probably be improved but for now this fixes ingestion of ODC files with fdb which requires that columns containing mars key values be constant.