### PR TITLE
Python Wrapper Wheel: fix proj name

### DIFF
--- a/python_wrapper/setup.cfg
+++ b/python_wrapper/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-description = "odc"
+description = "odclib"
 long_description = file: README.md
 long_description_content_type = text/markdown
 author = file: AUTHORS


### PR DESCRIPTION
Without this, the wheel upload to pypi fails, because it tries `odc` project which we don't own, instead of the proper `odclib` one