### PR TITLE
Deprecate NonCopyable in favour of explicitly deleted ctors

### DIFF
--- a/src/odc/ODBAPISettings.h
+++ b/src/odc/ODBAPISettings.h
@@ -21,10 +21,13 @@ class DataHandle;
 
 namespace odc {
 
-class ODBAPISettings : private eckit::NonCopyable {
+class ODBAPISettings {
 public:
 
     static ODBAPISettings& instance();
+
+    ODBAPISettings(const ODBAPISettings&)            = delete;
+    ODBAPISettings& operator=(const ODBAPISettings&) = delete;
 
     size_t headerBufferSize();
     void headerBufferSize(size_t);

--- a/src/odc/Reader.h
+++ b/src/odc/Reader.h
@@ -30,7 +30,7 @@ class DataHandle;
 
 namespace odc {
 
-class Reader : public eckit::NonCopyable {
+class Reader {
 public:
 
     typedef IteratorProxy<ReaderIterator, Reader, const double> iterator;
@@ -39,6 +39,9 @@ public:
     Reader(eckit::DataHandle&);
     Reader(const eckit::PathName& path);
     Reader();
+
+    Reader(const Reader&)            = delete;
+    Reader& operator=(const Reader&) = delete;
 
     Reader(Reader&& rhs);
     Reader& operator=(Reader&& rhs);

--- a/src/odc/SelectIterator.h
+++ b/src/odc/SelectIterator.h
@@ -43,10 +43,14 @@ namespace odc {
 
 //----------------------------------------------------------------------------------------------------------------------
 
-class SelectIterator : private eckit::NonCopyable {
+class SelectIterator {
 public:
 
     SelectIterator(const std::string& select, eckit::sql::SQLSession& session, sql::SQLSelectOutput& output);
+
+    SelectIterator(const SelectIterator&)            = delete;
+    SelectIterator& operator=(const SelectIterator&) = delete;
+
     ~SelectIterator();
 
     // TODO: New dataset

--- a/src/odc/core/CodecFactory.h
+++ b/src/odc/core/CodecFactory.h
@@ -22,8 +22,6 @@
 #include <string>
 #include <string_view>
 
-#include "eckit/memory/NonCopyable.h"
-
 #include "odc/ODBAPISettings.h"
 #include "odc/api/ColumnType.h"
 #include "odc/core/Exceptions.h"
@@ -41,11 +39,15 @@ struct SameByteOrder;
 struct OtherByteOrder;
 
 
-class CodecFactory : private eckit::NonCopyable {
+class CodecFactory {
 
 public:  // methods
 
     CodecFactory();
+
+    CodecFactory(const CodecFactory&)            = delete;
+    CodecFactory& operator=(const CodecFactory&) = delete;
+
     ~CodecFactory();
 
     static CodecFactory& instance();

--- a/src/odc/core/Header.h
+++ b/src/odc/core/Header.h
@@ -23,7 +23,6 @@
 #include <vector>
 
 #include "eckit/io/Buffer.h"
-#include "eckit/memory/NonCopyable.h"
 
 namespace eckit {
 class DataHandle;
@@ -47,11 +46,15 @@ const int32_t FORMAT_VERSION_NUMBER_MINOR = 5;
 
 //----------------------------------------------------------------------------------------------------------------------
 
-class Header : private eckit::NonCopyable {
+class Header {
 
 public:  // methods
 
     Header(MetaData& md, Properties& props);
+
+    Header(const Header&)            = delete;
+    Header& operator=(const Header&) = delete;
+
     ~Header();
 
     size_t dataSize() const { return dataSize_; }

--- a/src/odc/csv/TextReader.h
+++ b/src/odc/csv/TextReader.h
@@ -20,8 +20,6 @@
 #include <Python.h>
 #endif
 
-#include "eckit/memory/NonCopyable.h"
-
 #include "odc/IteratorProxy.h"
 
 namespace eckit {
@@ -34,7 +32,7 @@ namespace odc {
 
 class TextReaderIterator;
 
-class TextReader : private eckit::NonCopyable {
+class TextReader {
 public:
 
     typedef IteratorProxy<TextReaderIterator, TextReader, double> iterator;
@@ -42,6 +40,9 @@ public:
 
     TextReader(std::istream&, const std::string& delimiter);
     TextReader(const std::string& path, const std::string& delimiter);
+
+    TextReader(const TextReader&)            = delete;
+    TextReader& operator=(const TextReader&) = delete;
 
     TextReader(TextReader&&);
     TextReader& operator=(TextReader&&);

--- a/src/odc/csv/TextReaderIterator.h
+++ b/src/odc/csv/TextReaderIterator.h
@@ -37,11 +37,15 @@ namespace odc {
 
 class TextReader;
 
-class TextReaderIterator : private eckit::NonCopyable {
+class TextReaderIterator {
 public:
 
     TextReaderIterator(TextReader& owner);
     TextReaderIterator(TextReader& owner, const eckit::PathName&);
+
+    TextReaderIterator(const TextReaderIterator&)            = delete;
+    TextReaderIterator& operator=(const TextReaderIterator&) = delete;
+
     ~TextReaderIterator();
 
     bool isNewDataset();
@@ -72,10 +76,6 @@ public:
     size_t rowDataSizeDoubles() const { return rowDataSizeDoubles_; }
 
 private:
-
-    // No copy allowed.
-    TextReaderIterator(const TextReaderIterator&);
-    TextReaderIterator& operator=(const TextReaderIterator&);
 
     void initRowBuffer();
     void parseHeader();


### PR DESCRIPTION
### Description

An attempt to modernize the code base, by deprecating the "old style" NonCopyable in favour of explicitly deleting copy ctor/copy assignment operator.

This follows the advice of the CppCoreGuidelines, which states = delete is preferred -- see the discussion https://github.com/isocpp/CppCoreGuidelines/issues/1354#issuecomment-470669557.

The proposed effectively remove a "small" eckit dependency

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 

<!-- PREVIEW-URL_BEGIN -->
📖 Documentation 📖
https://sites.ecmwf.int/docs/dev-section/odc/pull-requests/PR-48
<!-- PREVIEW-URL_END -->